### PR TITLE
feat(search): PostgreSQL FTS, tag filtering, and EPIC 1 gap closure

### DIFF
--- a/publisher/src/main/resources/application.properties
+++ b/publisher/src/main/resources/application.properties
@@ -32,5 +32,7 @@ stillum.storage.bundles-bucket=stillum-bundles
 %test.quarkus.s3.path-style-access=true
 
 stillum.storage.bundle-no-overwrite=true
-%test.stillum.rls.assume-role=stillum_app
+
+# --- RLS ---
+stillum.rls.assume-role=${STILLUM_RLS_ROLE:stillum_app}
 

--- a/registry-api/src/main/java/com/stillum/registry/resource/SearchResource.java
+++ b/registry-api/src/main/java/com/stillum/registry/resource/SearchResource.java
@@ -30,10 +30,11 @@ public class SearchResource {
             @QueryParam("type") ArtifactType type,
             @QueryParam("status") ArtifactStatus status,
             @QueryParam("area") String area,
+            @QueryParam("tag") String tag,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("20") int size) {
         PagedResponse<ArtifactResponse> resp =
-                service.search(tenantId, query, type, status, area, page, size);
+                service.search(tenantId, query, type, status, area, tag, page, size);
         return Response.ok(resp).build();
     }
 }

--- a/registry-api/src/main/java/com/stillum/registry/service/SearchService.java
+++ b/registry-api/src/main/java/com/stillum/registry/service/SearchService.java
@@ -9,9 +9,11 @@ import com.stillum.registry.filter.EnforceTenantRls;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
+import jakarta.persistence.Query;
 import jakarta.transaction.Transactional;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -28,83 +30,83 @@ public class SearchService {
             ArtifactType type,
             ArtifactStatus status,
             String area,
+            String tag,
             int page,
             int pageSize) {
-        StringBuilder jpql = new StringBuilder(
-            "SELECT a FROM Artifact a WHERE a.tenantId = :tid");
 
-        if (query != null && !query.isBlank()) {
-            jpql.append(
-                " AND (LOWER(a.title) LIKE :q OR LOWER(a.description) LIKE :q)");
-        }
-        if (type != null) {
-            jpql.append(" AND a.type = :type");
-        }
-        if (status != null) {
-            jpql.append(" AND a.status = :status");
-        }
-        if (area != null && !area.isBlank()) {
-            jpql.append(" AND a.area = :area");
-        }
-        jpql.append(" ORDER BY a.updatedAt DESC");
-
-        TypedQuery<Artifact> q = em.createQuery(jpql.toString(), Artifact.class);
-        q.setParameter("tid", tenantId);
-
-        if (query != null && !query.isBlank()) {
-            q.setParameter("q", "%" + query.toLowerCase() + "%");
-        }
-        if (type != null) {
-            q.setParameter("type", type);
-        }
-        if (status != null) {
-            q.setParameter("status", status);
-        }
-        if (area != null && !area.isBlank()) {
-            q.setParameter("area", area);
-        }
+        StringBuilder where = buildWhere(tenantId, query, type, status, area, tag);
+        Map<String, Object> params = buildParams(tenantId, query, type, status, area, tag);
 
         // Count query
-        StringBuilder countJpql = new StringBuilder(
-            "SELECT COUNT(a) FROM Artifact a WHERE a.tenantId = :tid");
-        if (query != null && !query.isBlank()) {
-            countJpql.append(
-                " AND (LOWER(a.title) LIKE :q OR LOWER(a.description) LIKE :q)");
+        Query cq = em.createNativeQuery("SELECT COUNT(*) FROM artifact" + where);
+        for (Map.Entry<String, Object> e : params.entrySet()) {
+            cq.setParameter(e.getKey(), e.getValue());
         }
-        if (type != null) {
-            countJpql.append(" AND a.type = :type");
-        }
-        if (status != null) {
-            countJpql.append(" AND a.status = :status");
-        }
-        if (area != null && !area.isBlank()) {
-            countJpql.append(" AND a.area = :area");
-        }
+        long total = ((Number) cq.getSingleResult()).longValue();
 
-        TypedQuery<Long> cq = em.createQuery(countJpql.toString(), Long.class);
-        cq.setParameter("tid", tenantId);
-        if (query != null && !query.isBlank()) {
-            cq.setParameter("q", "%" + query.toLowerCase() + "%");
+        // Data query
+        String dataSql = "SELECT * FROM artifact" + where
+                + " ORDER BY updated_at DESC LIMIT :limit OFFSET :offset";
+        Query dq = em.createNativeQuery(dataSql, Artifact.class);
+        for (Map.Entry<String, Object> e : params.entrySet()) {
+            dq.setParameter(e.getKey(), e.getValue());
         }
-        if (type != null) {
-            cq.setParameter("type", type);
-        }
-        if (status != null) {
-            cq.setParameter("status", status);
-        }
-        if (area != null && !area.isBlank()) {
-            cq.setParameter("area", area);
-        }
+        dq.setParameter("limit", pageSize);
+        dq.setParameter("offset", page * pageSize);
 
-        long total = cq.getSingleResult();
-        List<ArtifactResponse> items = q
-                .setFirstResult(page * pageSize)
-                .setMaxResults(pageSize)
-                .getResultList()
-                .stream()
+        @SuppressWarnings("unchecked")
+        List<Artifact> results = dq.getResultList();
+
+        List<ArtifactResponse> items = results.stream()
                 .map(ArtifactResponse::from)
                 .toList();
 
         return PagedResponse.of(items, page, pageSize, total);
+    }
+
+    private StringBuilder buildWhere(
+            UUID tenantId, String query, ArtifactType type,
+            ArtifactStatus status, String area, String tag) {
+        StringBuilder w = new StringBuilder(" WHERE tenant_id = :tid");
+        if (query != null && !query.isBlank()) {
+            w.append(" AND to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, ''))")
+             .append(" @@ plainto_tsquery('simple', :q)");
+        }
+        if (type != null) {
+            w.append(" AND type = :type");
+        }
+        if (status != null) {
+            w.append(" AND status = :status");
+        }
+        if (area != null && !area.isBlank()) {
+            w.append(" AND area = :area");
+        }
+        if (tag != null && !tag.isBlank()) {
+            w.append(" AND :tag = ANY(tags)");
+        }
+        return w;
+    }
+
+    private Map<String, Object> buildParams(
+            UUID tenantId, String query, ArtifactType type,
+            ArtifactStatus status, String area, String tag) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("tid", tenantId);
+        if (query != null && !query.isBlank()) {
+            params.put("q", query);
+        }
+        if (type != null) {
+            params.put("type", type.name());
+        }
+        if (status != null) {
+            params.put("status", status.name());
+        }
+        if (area != null && !area.isBlank()) {
+            params.put("area", area);
+        }
+        if (tag != null && !tag.isBlank()) {
+            params.put("tag", tag);
+        }
+        return params;
     }
 }

--- a/registry-api/src/main/resources/application.properties
+++ b/registry-api/src/main/resources/application.properties
@@ -31,6 +31,9 @@ stillum.storage.artifacts-bucket=stillum-artifacts
 stillum.storage.bundles-bucket=stillum-bundles
 stillum.storage.presigned-url-expiry-seconds=300
 
+# --- RLS ---
+stillum.rls.assume-role=${STILLUM_RLS_ROLE:stillum_app}
+
 # --- OpenAPI ---
 quarkus.swagger-ui.always-include=true
 mp.openapi.extensions.smallrye.info.title=Stillum Registry API
@@ -47,4 +50,3 @@ mp.openapi.extensions.smallrye.info.description=API per la gestione di artefatti
 # S3 dev service (LocalStack) avviato automaticamente da Quarkus per i test
 %test.quarkus.s3.devservices.enabled=true
 %test.quarkus.s3.path-style-access=true
-%test.stillum.rls.assume-role=stillum_app

--- a/registry-api/src/test/java/com/stillum/registry/resource/SearchResourceTest.java
+++ b/registry-api/src/test/java/com/stillum/registry/resource/SearchResourceTest.java
@@ -1,0 +1,230 @@
+package com.stillum.registry.resource;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class SearchResourceTest {
+
+    static final String TENANT_ID = "00000000-0000-0000-0000-000000000001";
+    static final String TENANT_B  = "00000000-0000-0000-0000-000000000002";
+    static final String SEARCH_PATH   = "/api/tenants/" + TENANT_ID + "/search/artifacts";
+    static final String ARTIFACTS_PATH = "/api/tenants/" + TENANT_ID + "/artifacts";
+
+    @Test
+    void search_byQuery_returnsFtsMatches() {
+        createArtifact("PROCESS", "SRT_FTS_Invoice Processing Workflow",
+                "automated invoice handling and approval", "Finance", "srt_fts");
+
+        createArtifact("RULE", "SRT_FTS_Employee Leave Policy",
+                "rules for leave management", "HR", "srt_fts");
+
+        given()
+            .queryParam("q", "invoice")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", not(empty()))
+            .body("items.title", hasItem("SRT_FTS_Invoice Processing Workflow"));
+    }
+
+    @Test
+    void search_byTag_returnsTaggedArtifacts() {
+        createArtifact("PROCESS", "SRT_Tag_Finance Process",
+                null, null, "srt_tag_finance", "automation");
+
+        createArtifact("RULE", "SRT_Tag_HR Rule",
+                null, null, "srt_tag_hr");
+
+        given()
+            .queryParam("tag", "srt_tag_finance")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", not(empty()))
+            .body("items.tags", everyItem(hasItem("srt_tag_finance")));
+    }
+
+    @Test
+    void search_byType_returnsFiltered() {
+        createArtifact("FORM", "SRT_Type_Registration Form",
+                null, null, "srt_type");
+
+        createArtifact("RULE", "SRT_Type_Validation Rule",
+                null, null, "srt_type");
+
+        given()
+            .queryParam("tag", "srt_type")
+            .queryParam("type", "FORM")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", not(empty()))
+            .body("items.type", everyItem(is("FORM")));
+    }
+
+    @Test
+    void search_byStatus_returnsFiltered() {
+        createArtifact("PROCESS", "SRT_Status_Draft Process",
+                null, null, "srt_status");
+
+        given()
+            .queryParam("tag", "srt_status")
+            .queryParam("status", "DRAFT")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", not(empty()))
+            .body("items.status", everyItem(is("DRAFT")));
+
+        given()
+            .queryParam("tag", "srt_status")
+            .queryParam("status", "PUBLISHED")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", empty())
+            .body("total", is(0));
+    }
+
+    @Test
+    void search_combinedFilters_returnsIntersection() {
+        createArtifact("PROCESS", "SRT_Combined_Compliance Process Alpha",
+                "compliance workflow", "Legal", "srt_combined_compliance");
+
+        createArtifact("RULE", "SRT_Combined_Compliance Rule Beta",
+                "compliance rule", "Legal", "srt_combined_compliance");
+
+        createArtifact("PROCESS", "SRT_Combined_HR Process Gamma",
+                "hr workflow", "HR", "srt_combined_hr");
+
+        given()
+            .queryParam("q", "compliance")
+            .queryParam("type", "PROCESS")
+            .queryParam("tag", "srt_combined_compliance")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", hasSize(1))
+            .body("items[0].title", is("SRT_Combined_Compliance Process Alpha"));
+    }
+
+    @Test
+    void search_noResults_returnsEmptyPage() {
+        given()
+            .queryParam("q", "srt_nonexistent_zzz_999")
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", empty())
+            .body("total", is(0));
+    }
+
+    @Test
+    void search_pagination_works() {
+        for (int i = 1; i <= 3; i++) {
+            createArtifact("PROCESS", "SRT_Pag_Process " + i,
+                    null, null, "srt_pagination");
+        }
+
+        given()
+            .queryParam("tag", "srt_pagination")
+            .queryParam("page", 0)
+            .queryParam("size", 2)
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", hasSize(2))
+            .body("page", is(0))
+            .body("pageSize", is(2))
+            .body("total", is(3));
+
+        given()
+            .queryParam("tag", "srt_pagination")
+            .queryParam("page", 1)
+            .queryParam("size", 2)
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", hasSize(1))
+            .body("page", is(1));
+    }
+
+    @Test
+    void search_noParams_returnsAll() {
+        given()
+        .when()
+            .get(SEARCH_PATH)
+        .then()
+            .statusCode(200)
+            .body("items", not(empty()))
+            .body("page", is(0))
+            .body("items", notNullValue());
+    }
+
+    @Test
+    void search_tenantIsolation_otherTenantNotVisible() {
+        createArtifact("PROCESS", "SRT_Isolation_Secret Process",
+                null, null, "srt_isolation");
+
+        String searchPathB = "/api/tenants/" + TENANT_B + "/search/artifacts";
+        given()
+            .queryParam("tag", "srt_isolation")
+        .when()
+            .get(searchPathB)
+        .then()
+            .statusCode(200)
+            .body("items", empty())
+            .body("total", is(0));
+    }
+
+    private String createArtifact(String type, String title, String description,
+                                   String area, String... tags) {
+        StringBuilder json = new StringBuilder();
+        json.append("{\"type\":\"").append(type).append("\",");
+        json.append("\"title\":\"").append(title).append("\"");
+        if (description != null) {
+            json.append(",\"description\":\"").append(description).append("\"");
+        }
+        if (area != null) {
+            json.append(",\"area\":\"").append(area).append("\"");
+        }
+        if (tags.length > 0) {
+            json.append(",\"tags\":[");
+            for (int i = 0; i < tags.length; i++) {
+                if (i > 0) json.append(",");
+                json.append("\"").append(tags[i]).append("\"");
+            }
+            json.append("]");
+        }
+        json.append("}");
+
+        return given()
+            .contentType(ContentType.JSON)
+            .body(json.toString())
+        .when()
+            .post(ARTIFACTS_PATH)
+        .then()
+            .statusCode(201)
+            .extract().path("id");
+    }
+}


### PR DESCRIPTION
## Summary

- Sostituisce la ricerca `LIKE` nel `SearchService` con **PostgreSQL full-text search** (`to_tsvector`/`plainto_tsquery`), sfruttando l'indice GIN `idx_artifact_fts` già presente
- Aggiunge il **filtro per tag** (`?tag=<value>`) alla `SearchResource` e al `SearchService`, sfruttando l'indice GIN `idx_artifact_tags` con l'operatore `ANY(tags)`
- Promuove la configurazione RLS `stillum.rls.assume-role` dal profilo `%test` a **profile-independent** (con fallback su env var `STILLUM_RLS_ROLE`), garantendo che `SET LOCAL ROLE stillum_app` venga eseguito anche in produzione
- Aggiunge **9 test di integrazione** per `SearchResourceTest` che coprono: FTS match, tag filter, type filter, status filter, filtri combinati, empty page, paginazione, comportamento senza parametri, e isolamento multi-tenant

## Modifiche

| File | Tipo | Descrizione |
|------|------|-------------|
| `registry-api/.../SearchService.java` | Modifica | Riscrittura con native SQL: FTS + tag filter + helper `buildWhere`/`buildParams` |
| `registry-api/.../SearchResource.java` | Modifica | Aggiunto `@QueryParam("tag") String tag` |
| `registry-api/.../SearchResourceTest.java` | Nuovo | 9 integration test con prefissi unici per isolamento dati |
| `registry-api/.../application.properties` | Modifica | `stillum.rls.assume-role` promosso a profile-independent |
| `publisher/.../application.properties` | Modifica | Stessa promozione RLS config |

## Test plan

- [x] `mvn verify -pl registry-api` con Docker attivo — tutti i 9 nuovi test devono passare
- [x] `mvn verify -pl publisher` — nessuna regressione
- [x] Test manuale: `GET /api/tenants/{tid}/search/artifacts?q=onboarding` → FTS match sul seed data
- [x] Test manuale: `GET /api/tenants/{tid}/search/artifacts?tag=bpmn` → match tag dal seed data
- [x] Test manuale: `GET /api/tenants/{tid}/search/artifacts?q=nonexistent` → empty page

🤖 Generated with [Claude Code](https://claude.com/claude-code)